### PR TITLE
feat: standardize error messages

### DIFF
--- a/src/models/session.ts
+++ b/src/models/session.ts
@@ -1,4 +1,5 @@
 import * as User from './user';
+import { toError } from '../utils';
 import * as database from '../utils/database';
 import * as cookies from '../utils/cookies';
 import * as keys from '../utils/keys';
@@ -60,22 +61,22 @@ export async function destroy(item: Session): Promise<Session | void> {
 /** Parse the "Cookie" request header; attempt valid `Session` -> `User` lookup */
 export async function identify(req: ServerRequest, res: ServerResponse): Promise<User.User | void> {
 	const cookie = req.headers.get('cookie');
-	if (!cookie) return res.send(401, 'Missing cookie header');
+	if (!cookie) return toError(res, 401, 'Missing cookie header');
 
 	const sid = cookies.parse(cookie);
-	if (!sid) return res.send(401, 'Invalid cookie value');
+	if (!sid) return toError(res, 401, 'Invalid cookie value');
 
 	const session = await lookup(sid);
-	if (!session) return res.send(401, 'Invalid cookie token');
+	if (!session) return toError(res, 401, 'Invalid cookie token');
 
 	if (Date.now() >= session.expires) {
 		await database.remove('session', session.uid);
-		return res.send(401, 'Expired session');
+		return toError(res, 401, 'Expired session');
 	}
 
 	const user = await User.lookup(session.userid);
 	if (!user || user.uid !== session.userid) {
-		return res.send(401, 'Invalid session');
+		return toError(res, 401, 'Invalid session');
 	}
 
 	return user;
@@ -97,7 +98,7 @@ export function authenticate(handler: AuthorizedHandler): Handler {
 			(req as AuthorizedRequest).user = user;
 			return handler(req as AuthorizedRequest, res);
 		} catch (err) {
-			res.send(err.statusCode || 500, err.data);
+			toError(res, err.statusCode || 500, err.data)
 		}
 	};
 }

--- a/src/routes/docs.ts
+++ b/src/routes/docs.ts
@@ -1,4 +1,5 @@
 import * as Docs from "../models/docs";
+import { toError } from "../utils";
 
 import type { Handler } from "worktop";
 import type { Params } from "worktop/request";
@@ -15,10 +16,7 @@ export const list: Handler<ParamsDocsList> = async (req, res) => {
 	const docs = await Docs.list(project, type, version, full);
 
 	if (docs) res.send(200, docs);
-	else
-		res.send(404, {
-			message: `'${project}@${version}' '${type}' entry not found.`,
-		});
+	else toError(res, 404, `'${project}@${version}' '${type}' entry not found.`);
 };
 
 // GET /docs/:project/:type/:slug(?version=beta)
@@ -30,7 +28,9 @@ export const entry: Handler<ParamsDocsEntry> = async (req, res) => {
 
 	if (entry) res.send(200, entry);
 	else
-		res.send(404, {
-			message: `'${project}@${version}' '${type}' entry for '${slug}' not found.`,
-		});
+		toError(
+			res,
+			404,
+			`'${project}@${version}' '${type}' entry for '${slug}' not found.`
+		);
 };

--- a/src/routes/todos.ts
+++ b/src/routes/todos.ts
@@ -1,4 +1,5 @@
 import * as TodoList from '../models/todolist';
+import { toError } from '../utils';
 
 import type { Handler } from 'worktop';
 import type { Params } from 'worktop/request';
@@ -10,18 +11,18 @@ type ParamsUserID = Params & { userid: GuestID };
 export const list: Handler<ParamsUserID> = async (req, res) => {
 	const todos = await TodoList.lookup(req.params.userid);
 	if (todos) res.send(200, todos);
-	else res.send(404, { message: 'Todo list not found' });
+	else toError(res, 404, 'Todo list not found');
 };
 
 // POST /gists/:userid
 export const create: Handler<ParamsUserID> = async (req, res) => {
 	const input = await req.body<{ text: string }>();
-	if (!input) return res.send(400, 'Missing request body');
+	if (!input) return toError(res, 400, 'Missing request body');
 
 	const todo = await TodoList.insert(req.params.userid, input.text);
 
 	if (todo) res.send(201, todo);
-	else res.send(500, { message: 'Error creating todo' });
+	else toError(res, 500, 'Error creating todo');
 };
 
 // PATCH /gists/:userid/:uid
@@ -29,12 +30,12 @@ export const update: Handler = async (req, res) => {
 	const { userid, uid } = req.params;
 
 	const input = await req.body<{ text?: string, done?: boolean }>();
-	if (!input) return res.send(400, 'Missing request body');
+	if (!input) return toError(res, 400, 'Missing request body');
 
 	const todo = await TodoList.update(userid, uid as TodoID, input);
 
 	if (todo) res.send(200, todo);
-	else res.send(500, { message: 'Error updating todo' });
+	else toError(res, 500, 'Error updating todo');
 };
 
 // DELETE /gists/:userid/:uid
@@ -42,5 +43,5 @@ export const destroy: Handler = async (req, res) => {
 	const { userid, uid } = req.params;
 
 	if (await TodoList.destroy(userid, uid as TodoID)) res.send(200, {});
-	else res.send(500, { message: 'Error deleting todo' });
+	else toError(res, 500, 'Error deleting todo');
 };

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,0 +1,5 @@
+import type { ServerResponse } from 'worktop/response';
+
+export function toError(res: ServerResponse, status: number, message: string) {
+	res.send(status, { status, message });
+}


### PR DESCRIPTION
All 4xx and 5xx responses pass through the new `toError` helper, which ensures that all API error responses are: 

```ts
{
  status: number;
  message: string;
}
```

Closes #1 