### PR TITLE
feat: api for docs

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,28 +1,28 @@
-import { Router } from "worktop";
-import * as Cache from "worktop/cache";
-import * as Gists from "./routes/gists";
-import * as Todos from "./routes/todos";
-import * as Auth from "./routes/auth";
-import * as Docs from "./routes/docs";
+import { Router } from 'worktop';
+import * as Cache from 'worktop/cache';
+import * as Gists from './routes/gists';
+import * as Todos from './routes/todos';
+import * as Auth from './routes/auth';
+import * as Docs from './routes/docs';
 
 const API = new Router();
 
-API.add("GET", "/auth/login", Auth.login);
-API.add("GET", "/auth/callback", Auth.callback);
-API.add("GET", "/auth/logout", Auth.logout);
+API.add('GET', '/auth/login', Auth.login);
+API.add('GET', '/auth/callback', Auth.callback);
+API.add('GET', '/auth/logout', Auth.logout);
 
-API.add("GET", "/gists", Gists.list);
-API.add("POST", "/gists", Gists.create);
-API.add("GET", "/gists/:uid", Gists.show);
-API.add("PUT", "/gists/:uid", Gists.update);
-API.add("DELETE", "/gists/:uid", Gists.destroy);
+API.add('GET', '/gists', Gists.list);
+API.add('POST', '/gists', Gists.create);
+API.add('GET', '/gists/:uid', Gists.show);
+API.add('PUT', '/gists/:uid', Gists.update);
+API.add('DELETE', '/gists/:uid', Gists.destroy);
 
-API.add("GET", "/todos/:userid", Todos.list);
-API.add("POST", "/todos/:userid", Todos.create);
-API.add("PATCH", "/todos/:userid/:uid", Todos.update);
-API.add("DELETE", "/todos/:userid/:uid", Todos.destroy);
+API.add('GET', '/todos/:userid', Todos.list);
+API.add('POST', '/todos/:userid', Todos.create);
+API.add('PATCH', '/todos/:userid/:uid', Todos.update);
+API.add('DELETE', '/todos/:userid/:uid', Todos.destroy);
 
-API.add("GET", "/docs/:project/:type", Docs.list);
-API.add("GET", "/docs/:project/:type/:slug", Docs.entry);
+API.add('GET', '/docs/:project/:type', Docs.list);
+API.add('GET', '/docs/:project/:type/:slug', Docs.entry);
 
 Cache.listen(API.run);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,24 +1,28 @@
-import { Router } from 'worktop';
-import * as Cache from 'worktop/cache';
-import * as Gists from './routes/gists';
-import * as Todos from './routes/todos';
-import * as Auth from './routes/auth';
+import { Router } from "worktop";
+import * as Cache from "worktop/cache";
+import * as Gists from "./routes/gists";
+import * as Todos from "./routes/todos";
+import * as Auth from "./routes/auth";
+import * as Docs from "./routes/docs";
 
 const API = new Router();
 
-API.add('GET', '/auth/login', Auth.login);
-API.add('GET', '/auth/callback', Auth.callback);
-API.add('GET', '/auth/logout', Auth.logout);
+API.add("GET", "/auth/login", Auth.login);
+API.add("GET", "/auth/callback", Auth.callback);
+API.add("GET", "/auth/logout", Auth.logout);
 
-API.add('GET', '/gists', Gists.list);
-API.add('POST', '/gists', Gists.create);
-API.add('GET', '/gists/:uid', Gists.show);
-API.add('PUT', '/gists/:uid', Gists.update);
-API.add('DELETE', '/gists/:uid', Gists.destroy);
+API.add("GET", "/gists", Gists.list);
+API.add("POST", "/gists", Gists.create);
+API.add("GET", "/gists/:uid", Gists.show);
+API.add("PUT", "/gists/:uid", Gists.update);
+API.add("DELETE", "/gists/:uid", Gists.destroy);
 
-API.add('GET', '/todos/:userid', Todos.list);
-API.add('POST', '/todos/:userid', Todos.create);
-API.add('PATCH', '/todos/:userid/:uid', Todos.update);
-API.add('DELETE', '/todos/:userid/:uid', Todos.destroy);
+API.add("GET", "/todos/:userid", Todos.list);
+API.add("POST", "/todos/:userid", Todos.create);
+API.add("PATCH", "/todos/:userid/:uid", Todos.update);
+API.add("DELETE", "/todos/:userid/:uid", Todos.destroy);
+
+API.add("GET", "/docs/:project/:type", Docs.list);
+API.add("GET", "/docs/:project/:type/:slug", Docs.entry);
 
 Cache.listen(API.run);

--- a/src/models/docs.ts
+++ b/src/models/docs.ts
@@ -1,0 +1,21 @@
+import type { KV } from "worktop/kv";
+
+declare const DOCS: KV.Namespace;
+
+export function list(
+	project: string,
+	type: string,
+	version: string,
+	full: boolean
+): Promise<string> {
+	return DOCS.get(`${project}@${version}:${type}:${full ? "content" : "list"}`);
+}
+
+export function entry(
+	project: string,
+	type: string,
+	slug: string,
+	version: string
+): Promise<string> {
+	return DOCS.get(`${project}@${version}:${type}:${slug}`);
+}

--- a/src/routes/docs.ts
+++ b/src/routes/docs.ts
@@ -1,0 +1,36 @@
+import * as Docs from "../models/docs";
+
+import type { Handler } from "worktop";
+import type { Params } from "worktop/request";
+
+type ParamsDocsList = Params & { project: string; type: string };
+type ParamsDocsEntry = Params & { project: string; type: string; slug: string };
+
+// GET /docs/:project/:type(?version=beta&content)
+export const list: Handler<ParamsDocsList> = async (req, res) => {
+	const { project, type } = req.params;
+	const version = req.query.get("version") || "latest";
+	const full = req.query.get("content") !== null;
+
+	const docs = await Docs.list(project, type, version, full);
+
+	if (docs) res.send(200, docs);
+	else
+		res.send(404, {
+			message: `'${project}@${version}' '${type}' entry not found.`,
+		});
+};
+
+// GET /docs/:project/:type/:slug(?version=beta)
+export const entry: Handler<ParamsDocsEntry> = async (req, res) => {
+	const { project, type, slug } = req.params;
+	const version = req.query.get("version") || "latest";
+
+	const entry = await Docs.entry(project, type, slug, version);
+
+	if (entry) res.send(200, entry);
+	else
+		res.send(404, {
+			message: `'${project}@${version}' '${type}' entry for '${slug}' not found.`,
+		});
+};


### PR DESCRIPTION
This adds two API endpoints for docs:

- `/docs/:project/:type` will return a list of metadata for the matching docs (an array of 'sections' with no formatted content). `/docs/kit/docs` would return an array of docs 'sections' without the actual HTML.
  - a `?content` query param will return the list _with_ the content. `/docs/kit/docs?content` would do the above but _with_ the actual HTML.
  - a `?version=version` query param will return the matching version of the docs (not currently utilised).
- `/docs/:project/:type/:slug` will return a specific piece of documentation (a single section from the above list). the `slug` is available in the list returned from the previous endpoint.
  -  a `?version=version` query param will return the matching version of the docs (not currently utilised).

Tested locally and works, but who knows.