### PR TITLE
ci(workflow): add cache to workflows using actions/setup-node

### DIFF
--- a/.github/workflows/branch.yml
+++ b/.github/workflows/branch.yml
@@ -3,37 +3,38 @@ name: Branch (CI)
 on:
   push:
     branches:
-      - '**'
+      - "**"
     tags-ignore:
-      - '**'
+      - "**"
     paths-ignore:
-      - '.vscode/**'
-      - 'scripts/**'
+      - ".vscode/**"
+      - "scripts/**"
 
   pull_request:
     branches:
-      - '**'
+      - "**"
     tags-ignore:
-      - '**'
+      - "**"
     paths-ignore:
-      - '.vscode/**'
-      - 'scripts/**'
+      - ".vscode/**"
+      - "scripts/**"
 
 jobs:
   test:
     name: Node.js v14
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-node@v1
-      with:
-        node-version: 14
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 14
+          cache: npm
 
-    - name: Install
-      run: yarn install
+      - name: Install
+        run: yarn install
 
-    - name: TypeCheck
-      run: yarn test
+      - name: TypeCheck
+        run: yarn test
 
-    - name: Compiles
-      run: yarn build
+      - name: Compiles
+        run: yarn build

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -3,9 +3,9 @@ name: Tag (CD)
 on:
   push:
     branches-ignore:
-      - '**'
+      - "**"
     tags:
-      - 'v**'
+      - "v**"
 
 env:
   # cfw authentication values
@@ -23,19 +23,20 @@ jobs:
     name: Node.js v14
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-node@v1
-      with:
-        node-version: 14
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 14
+          cache: npm
 
-    - name: Install
-      run: yarn install
+      - name: Install
+        run: yarn install
 
-    - name: Type Check
-      run: yarn test
+      - name: Type Check
+        run: yarn test
 
-    - name: Compiles
-      run: yarn build
+      - name: Compiles
+        run: yarn build
 
-    - name: Deploy
-      run: yarn deploy
+      - name: Deploy
+        run: yarn deploy


### PR DESCRIPTION
## Description

Add `cache` to workflows using `actions/setup-node`

## Context

`setup-node` GitHub Action just released a new option to add cache to steps using it.

You can find the details here: https://github.blog/changelog/2021-07-02-github-actions-setup-node-now-supports-dependency-caching/

---

🤖 This PR has been generated automatically by [this octoherd script](https://github.com/oscard0m/octoherd-script-add-cache-to-node-github-action), feel free to run it in your GitHub user/org repositories! 💪🏾
