### PR TITLE
serve docs as json

### DIFF
--- a/src/routes/docs.ts
+++ b/src/routes/docs.ts
@@ -7,6 +7,10 @@ import type { Params } from "worktop/request";
 type ParamsDocsList = Params & { project: string; type: string };
 type ParamsDocsEntry = Params & { project: string; type: string; slug: string };
 
+const headers = {
+	'content-type': 'application/json'
+};
+
 // GET /docs/:project/:type(?version=beta&content)
 export const list: Handler<ParamsDocsList> = async (req, res) => {
 	const { project, type } = req.params;
@@ -15,7 +19,7 @@ export const list: Handler<ParamsDocsList> = async (req, res) => {
 
 	const docs = await Docs.list(project, type, version, full);
 
-	if (docs) res.send(200, docs);
+	if (docs) res.send(200, docs, headers);
 	else toError(res, 404, `'${project}@${version}' '${type}' entry not found.`);
 };
 
@@ -26,7 +30,7 @@ export const entry: Handler<ParamsDocsEntry> = async (req, res) => {
 
 	const entry = await Docs.entry(project, type, slug, version);
 
-	if (entry) res.send(200, entry);
+	if (entry) res.send(200, entry, headers);
 	else
 		toError(
 			res,


### PR DESCRIPTION
this is the easiest option, and microscopically preferable to parsing the JSON only to immediately stringify it